### PR TITLE
Add support for multiple awair devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Run the binary with default arguments or provide your own:
 ```shell
 $ awair-local-prom-exporter --help
 Usage of awair-local-prom-exporter:
-  -awair_address string
-        Awair air-data URL (default "http://localhost/air-data/latest")
+  -awair_addresses string
+        Comma-separated list of Awair air-data URLs (default "http://localhost/air-data/latest")
   -listen string
         Listen address (default "0.0.0.0")
   -poll_frequency string
-        Time (seconds) to wait between polling device (default "30s")
+        Time (seconds) to wait between polling devices (default "30s")
   -port uint
         Listen port number (default 2112)
 ```
@@ -38,7 +38,7 @@ Documentation=https://github.com/ericvolp12/awair-local-prom-exporter
 [Service]
 Restart=always
 User=prometheus
-ExecStart=/<path_to_binary>/awair-local-prom-exporter --port 2155 --listen 0.0.0.0 --awair_address http://<local_awair_device_address>/air-data/latest --poll_frequency 30s
+ExecStart=/<path_to_binary>/awair-local-prom-exporter --port 2155 --listen 0.0.0.0 --awair_addresses http://<local_awair_device_address>/air-data/latest --poll_frequency 30s
 
 [Install]
 WantedBy=multi-user.target

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,14 +18,14 @@ import (
 type App struct {
 	ListenAddress     string
 	ListenPort        uint64
-	AwairAddress      string
+	AwairAddresses    []string
 	TimeBetweenChecks time.Duration
-	TempGauge         prometheus.Gauge
-	HumidityGauge     prometheus.Gauge
-	Co2Gauge          prometheus.Gauge
-	VOCGauge          prometheus.Gauge
-	PM25Gauge         prometheus.Gauge
-	ScoreGauge        prometheus.Gauge
+	TempGauge         *prometheus.GaugeVec
+	HumidityGauge     *prometheus.GaugeVec
+	Co2Gauge          *prometheus.GaugeVec
+	VOCGauge          *prometheus.GaugeVec
+	PM25Gauge         *prometheus.GaugeVec
+	ScoreGauge        *prometheus.GaugeVec
 	Logger            *zap.SugaredLogger
 }
 
@@ -62,14 +63,14 @@ func main() {
 	// Initialize Flags for configuration
 	listenAddress := flag.String("listen", "0.0.0.0", "Listen address")
 	listenPort := flag.Uint64("port", 2112, "Listen port number")
-	awairAddress := flag.String("awair_address", "http://localhost/air-data/latest", "Awair air-data URL")
-	pollFrequency := flag.String("poll_frequency", "30s", "Time (seconds) to wait between polling device")
+	awairAddresses := flag.String("awair_addresses", "http://localhost/air-data/latest", "Comma-separated list of Awair air-data URLs")
+	pollFrequency := flag.String("poll_frequency", "30s", "Time (seconds) to wait between polling devices")
 
 	flag.Parse()
 
 	app.ListenAddress = *listenAddress
 	app.ListenPort = *listenPort
-	app.AwairAddress = *awairAddress
+	app.AwairAddresses = strings.Split(*awairAddresses, ",")
 
 	// Parse time duration from poll frequency flag
 	app.TimeBetweenChecks, err = time.ParseDuration(*pollFrequency)
@@ -88,7 +89,7 @@ func main() {
 
 	listenString := fmt.Sprintf("%s:%d", app.ListenAddress, app.ListenPort)
 
-	app.Logger.Infof("Awair Poller started on (%+v) polling Awair Device at (%+v) every (%+v)", listenString, app.AwairAddress, app.TimeBetweenChecks)
+	app.Logger.Infof("Awair Poller started on (%+v) polling Awair Devices at (%+v) every (%+v)", listenString, app.AwairAddresses, app.TimeBetweenChecks)
 
 	err = http.ListenAndServe(listenString, nil)
 	if err != nil {
@@ -97,47 +98,47 @@ func main() {
 }
 
 func (app *App) initializeGauges() {
-	tempGauge := promauto.NewGauge(prometheus.GaugeOpts{
+	tempGauge := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "awair",
 		Subsystem: "climate",
 		Name:      "temp_c",
 		Help:      "The current temperature in C",
-	})
+	}, []string{"device_address"})
 
-	humidityGauge := promauto.NewGauge(prometheus.GaugeOpts{
+	humidityGauge := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "awair",
 		Subsystem: "climate",
 		Name:      "relative_humidity",
 		Help:      "The current % relative humidity",
-	})
+	}, []string{"device_address"})
 
-	co2Gauge := promauto.NewGauge(prometheus.GaugeOpts{
+	co2Gauge := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "awair",
 		Subsystem: "climate",
 		Name:      "co2_ppm",
 		Help:      "The current C02 PPM",
-	})
+	}, []string{"device_address"})
 
-	vocGauge := promauto.NewGauge(prometheus.GaugeOpts{
+	vocGauge := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "awair",
 		Subsystem: "climate",
 		Name:      "voc_ppb",
 		Help:      "The current Volatile Organic Compound reading in parts per billion",
-	})
+	}, []string{"device_address"})
 
-	pm25Gauge := promauto.NewGauge(prometheus.GaugeOpts{
+	pm25Gauge := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "awair",
 		Subsystem: "climate",
 		Name:      "pm25_ug_m3",
 		Help:      "The current concentration of 2.5 micron particles in micrograms per meter cubed",
-	})
+	}, []string{"device_address"})
 
-	scoreGauge := promauto.NewGauge(prometheus.GaugeOpts{
+	scoreGauge := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "awair",
 		Subsystem: "climate",
 		Name:      "score",
 		Help:      "The current Awair Score",
-	})
+	}, []string{"device_address"})
 
 	app.TempGauge = tempGauge
 	app.HumidityGauge = humidityGauge
@@ -150,16 +151,18 @@ func (app *App) initializeGauges() {
 func (app *App) recordMetrics() {
 	go func() {
 		for {
-			app.getAwairData()
+			for _, awairAddress := range app.AwairAddresses {
+				app.getAwairData(awairAddress)
+			}
 			time.Sleep(app.TimeBetweenChecks)
 		}
 	}()
 }
 
-func (app *App) getAwairData() {
-	resp, err := http.Get(app.AwairAddress)
+func (app *App) getAwairData(awairAddress string) {
+	resp, err := http.Get(awairAddress)
 	if err != nil {
-		app.Logger.Errorf("Failed to GET from configured Awair Address (%+v): %+v", app.AwairAddress, err)
+		app.Logger.Errorf("Failed to GET from configured Awair Address (%+v): %+v", awairAddress, err)
 		return
 	}
 	defer resp.Body.Close()
@@ -178,10 +181,9 @@ func (app *App) getAwairData() {
 		return
 	}
 
-	app.ScoreGauge.Set(float64(awairStats.Score))
-	app.TempGauge.Set(awairStats.Temp)
-	app.HumidityGauge.Set(awairStats.Humid)
-	app.Co2Gauge.Set(float64(awairStats.Co2))
-	app.VOCGauge.Set(float64(awairStats.Voc))
-	app.PM25Gauge.Set(float64(awairStats.Pm25))
+	app.TempGauge.WithLabelValues(awairAddress).Set(awairStats.Temp)
+	app.HumidityGauge.WithLabelValues(awairAddress).Set(awairStats.Humid)
+	app.Co2Gauge.WithLabelValues(awairAddress).Set(float64(awairStats.Co2))
+	app.VOCGauge.WithLabelValues(awairAddress).Set(float64(awairStats.Voc))
+	app.PM25Gauge.WithLabelValues(awairAddress).Set(float64(awairStats.Pm25))
 }


### PR DESCRIPTION
This pull request adds support for monitoring multiple Awair devices by providing a comma-separated list of device addresses at startup. Additionally, this change introduces labels to the Prometheus metrics, which allows users to identify the source Awair device for each data point.

## Changes:
- Refactored the main function to accept a comma-separated list of Awair device addresses.
- Updated the recordMetrics function to loop through the list of addresses and scrape data from each device.
- Modified Prometheus metrics to use NewGaugeVec instead of NewGauge to support labels.
- Added the awairAddress label to each metric, which is set during the getAwairData function call.

With these changes, users can monitor multiple Awair devices and analyze the collected data on a per-device basis using Prometheus labels. This provides a more flexible and comprehensive monitoring solution for environments with multiple Awair devices.