### PR TITLE
Added Aware Score metric and changed io/ioutil import to use standard io

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -167,7 +167,7 @@ func (app *App) getAwairData(awairAddress string) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		app.Logger.Errorf("Failed to read body from Awair GET response: %+v", err)
 		return
@@ -186,4 +186,5 @@ func (app *App) getAwairData(awairAddress string) {
 	app.Co2Gauge.WithLabelValues(awairAddress).Set(float64(awairStats.Co2))
 	app.VOCGauge.WithLabelValues(awairAddress).Set(float64(awairStats.Voc))
 	app.PM25Gauge.WithLabelValues(awairAddress).Set(float64(awairStats.Pm25))
+	app.ScoreGauge.WithLabelValues(awairAddress).Set(float64(awairStats.Score))
 }


### PR DESCRIPTION
I noticed that the score metric was included in the code, but wasn't surfaced as a collected metric. I've added it, as well as changed the io/iotuil import to just use io, since this is now the standard.